### PR TITLE
fix: 168 state is not always up to date when using multiple tabs

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,6 +1,6 @@
 import { Stanza, StanzaChangeTarget, type StanzaCoreConfig, utils } from '@getstanza/core'
 import { createContext, type StanzaContext } from './context'
-import localState from './localStorageStateProvider'
+import { localStorageStateProvider } from './localStorageStateProvider'
 export * from './feature'
 
 export type { StanzaContext }
@@ -10,7 +10,7 @@ const { getConfig, getEnablementNumber, getEnablementNumberStale } = utils.globa
 const contextChanges = new StanzaChangeTarget<StanzaContext>()
 
 export const init = (initialConfig: StanzaCoreConfig): void => {
-  Stanza.init(initialConfig, typeof window !== 'undefined' ? localState : undefined)
+  Stanza.init(initialConfig, typeof window !== 'undefined' ? localStorageStateProvider : undefined)
 
   const featureToContextMap = initialConfig.contextConfigs.reduce<Record<string, string[]>>((result, contextConfig) => {
     contextConfig.features.forEach(feature => {

--- a/packages/core/src/getFeatureStatesStale.ts
+++ b/packages/core/src/getFeatureStatesStale.ts
@@ -3,8 +3,8 @@ import { createFeatureState } from './models/createFeatureState'
 import { type FeatureState } from './models/featureState'
 
 export function getFeatureStatesStale (features: string[]): FeatureState[] {
-  const featureStates = features.map(name => getStateProvider().getFeatureState(name) ?? createFeatureState(name))
   const stateProvider = getStateProvider()
+  const featureStates = features.map(name => stateProvider.getFeatureState(name) ?? createFeatureState(name))
   featureStates.forEach(featureState => {
     stateProvider.setFeatureState(featureState)
   })

--- a/packages/core/src/models/localStateProvider.ts
+++ b/packages/core/src/models/localStateProvider.ts
@@ -1,7 +1,11 @@
 import { type FeatureState } from './featureState'
 
+type LocalStateChangeListener = (event: { oldValue: FeatureState | undefined, newValue: FeatureState }) => void
+
 export interface LocalStateProvider {
   setFeatureState: (context: FeatureState) => void
   getFeatureState: (name?: string) => FeatureState | undefined
   getAllFeatureStates: () => FeatureState[]
+  addChangeListener: (callback: LocalStateChangeListener) => () => void
+  removeChangeListener: (callback: LocalStateChangeListener) => void
 }

--- a/packages/core/src/utils/inMemoryLocalStateProvider.ts
+++ b/packages/core/src/utils/inMemoryLocalStateProvider.ts
@@ -1,12 +1,20 @@
 import { type FeatureState } from '../models/featureState'
 import { type LocalStateProvider } from '../models/localStateProvider'
+import { StanzaChangeTarget } from '../eventEmitter'
 
 export const createInMemoryLocalStateProvider = (): LocalStateProvider => {
   const localState = new Map<string, FeatureState>()
 
   function setFeatureState (featureState: FeatureState): void {
     const { featureName } = featureState
+    const oldValue = localState.get(featureName)
+
+    if (oldValue === featureState) {
+      return
+    }
+
     localState.set(featureName, featureState)
+    featureStateChangeEmitter.dispatchChange({ oldValue, newValue: featureState })
   }
 
   function getFeatureState (name?: string): FeatureState | undefined {
@@ -17,9 +25,13 @@ export const createInMemoryLocalStateProvider = (): LocalStateProvider => {
     return Array.from(localState.values())
   }
 
+  const featureStateChangeEmitter = new StanzaChangeTarget<{ oldValue: FeatureState | undefined, newValue: FeatureState }>()
+
   return {
     getFeatureState,
     setFeatureState,
-    getAllFeatureStates
+    getAllFeatureStates,
+    addChangeListener: (...args) => featureStateChangeEmitter.addChangeListener(...args),
+    removeChangeListener: (...args) => { featureStateChangeEmitter.removeChangeListener(...args) }
   }
 }


### PR DESCRIPTION
* move emitting change events to LocalStateProvider implementations
* use storage event to sync between tabs

fixes #168 